### PR TITLE
fix(Household.cat): fix lance count

### DIFF
--- a/Household.cat
+++ b/Household.cat
@@ -49,7 +49,7 @@
       <forceEntries>
         <forceEntry id="94fe-00c9-e912-2e1a" name="Lance" hidden="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e85f-1b78-055f-7791" type="min"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="e85f-1b78-055f-7791" type="min"/>
           </constraints>
           <categoryLinks>
             <categoryLink id="b745-75d7-9dbe-c305" name="Banner" hidden="false" targetId="917a-77ef-30e4-b812" primary="false">

--- a/Household.cat
+++ b/Household.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="20c9-0c15-57e3-bf84" name="Household" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="975a-00f4-df37-b565" gameSystemRevision="54" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="20c9-0c15-57e3-bf84" name="Household" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="975a-00f4-df37-b565" gameSystemRevision="54" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="abef-007d-766a-b940" name="Seneschal" publicationId="975a-00f4-pubN89746" page="35" hidden="false">
       <rules>


### PR DESCRIPTION
Currently the Lance Count can never be satisfied, because the Lances are counted per force and not including child forces..
This PR will change the count to also include child forces, so that the requirement of min. 1 lance can be satisfied.

Discord Bug Report: https://discord.com/channels/736936369670193332/1254837376577044511
